### PR TITLE
Synchronizing docs with S3 via Iron.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 site/index.php
+docsync/iron.json
+docsync/config.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 site/index.php
 docsync/iron.json
 docsync/config.sh
+docsync/*.zip

--- a/docsync/Dockerfile
+++ b/docsync/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu
+MAINTAINER "David Jay <davidgljay@gmail.com>"
+
+RUN apt-get update
+RUN apt-get install s3cmd -y
+RUN apt-get install git -y
+
+CMD bash

--- a/docsync/README.md
+++ b/docsync/README.md
@@ -1,0 +1,24 @@
+# Coral Projects Doc Sync
+
+This simple script copies the /site directory of the coralproject/docs repo to s3 for hosting. 
+
+It is drapped in a docker container and designed to be run on an Iron.io Iron Worker.
+
+##Installation
+
+1) Create an Iron.io account if you do not already have one.
+2) Create an Iron.io Project.
+3) In the project page, go to Credentials (Key icon) > Download iron.json file.
+4) Place the iron.json file in this directory (/docs/docsync)
+5) Install the Iron.io command line utility:
+  `curl -sSL https://cli.iron.io/install | sh`
+6) Copy `config.sample.sh` to `config.sh`
+7) Enter the following values into config.sh:
+  -GITHUB_REPO: Github repo to copy from
+  -S3_BUCKET: S3 bucket to copy to
+  -SUBDIR: Subdirectory of repo to copy, ie /site
+  -AWS_ACCESS_KEY: AWS access key
+  -AWS_SECRET_KEY: AWS secret key 
+8) Upload docsync to iron.io:
+ `zip -r docsync.zip . && iron worker upload --zip docsync.zip --name docsync coralproject/docsync ./docsync.sh`
+

--- a/docsync/config.sample.sh
+++ b/docsync/config.sample.sh
@@ -1,0 +1,5 @@
+export GITHUB_REPO= #Github repo to copy from, ie https://github.com/coralproject/docs.git
+export S3_BUCKET= #S3 bucket to copy to, ie coralproject-docs
+export SUBDIR= #Subdirectory of repo to copy, ie site
+export AWS_ACCESS_KEY= #AWS access key
+export AWS_SECRET_KEY= #AWS secret key

--- a/docsync/docsync.sh
+++ b/docsync/docsync.sh
@@ -1,0 +1,4 @@
+. ./config.sh
+git clone $GITHUB_REPO ./repo
+cd repo/$SUBDIR
+s3cmd -rP --access_key=$AWS_ACCESS_KEY --secret_key=$AWS_SECRET_KEY --region=US sync ./ s3://$S3_BUCKET


### PR DESCRIPTION
Adding a script to sync docs to S3 via iron.io. See README.md for installation instructions. 

I am adding this script as an iron worker and integrating with github, so pushes to S3 will happen automatically whenever this repo is updated on github. The process takes about 5 minutes (most of which is on Amazon's side).