### PR TITLE
Correct the capitalization of GitHub in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the documentation for The Coral Project, an initative by the [Mozilla Foundation](https://www.mozilla.org/en-US/foundation/) in partnership with [The New York Times](http://nytimes.com/), and [The Washington Post](http://washingtonpost.com/) to build an open source comment moderation system for newsrooms and media sites.
 
-Please report bugs and corrections via [Github issues](https://github.com/coralproject/docs/issues) in this repository.
+Please report bugs and corrections via [GitHub issues](https://github.com/coralproject/docs/issues) in this repository.
 
 Our live documentation lives at [https://docs.coralproject.net](https://docs.coralproject.net).
 


### PR DESCRIPTION
This pull request corrects the spelling of **GitHub** 🤓
https://github.com/

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
