### PR TITLE
Fix leftovers of merge conflict on Write Documentation page

### DIFF
--- a/docs_dir/contribute/writing_documentation.md
+++ b/docs_dir/contribute/writing_documentation.md
@@ -14,9 +14,6 @@ Here is, briefly, how our documentation works:
 
 There is a separate page for the [documentation style guide](docs_style_guide), that covers guidelines for how to organize and write instructions and tutorials, how to format text for consistency, and terminology.
 
-<<<<<<< Updated upstream
-## Installing MkDocs
-=======
 ## How the documentation is organized
 
 The documentation is organized into several categories:
@@ -52,7 +49,6 @@ git config --global user.email "you@email.com"
 Note that user.name should be your real name, not your GitHub username. The email you use in the user.email field will be used to associate your commits with your GitHub account.
 
 ## Install MkDocs
->>>>>>> Stashed changes
 
 The Coral Project's documentation uses the [MkDocs](http://www.mkdocs.org/) documentation system, which uses [Markdown](http://daringfireball.net/projects/markdown/) to format text. Before you can get started on writing and editing the documentation, you will need to have MkDocs installed.
 


### PR DESCRIPTION
I was checking out the "Write Documentation" contributing page and noticed the leftovers of a merge conflict. I assumed the `Install MKDocs` section went after `Install and setup Git`.

![screen shot 2017-06-26 at 10 25 33 pm](https://user-images.githubusercontent.com/763698/27572040-6e9a3556-5abe-11e7-95fb-c488a6a3ed68.png)
