### PR TITLE
pulled contribute and contanct menus

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,16 +3,7 @@ pages:
 - Home: 'index.md'
 - Ask User Guide: 'products/askuserguide.md'
 - Ask Technical Docs: 'products/ask.md'
-- Get Involved:
-  - Introduction: 'contribute/index.md'
-  - Contribute code: 'contribute/writing_code.md'
-  - Contribute to moderation style guide: 'contribute/docs_style_guide.md'
-  - Write documentation: 'contribute/writing_documentation.md'
-  - Code best practices: 'contribute/coding_style_guide.md'
-  - Submit feature requests: 'contribute/reporting_bugs.md'
-  - Report bugs: 'contribute/reporting_bugs.md'
-  - Our Code of Conduct: 'contribute/code_of_conduct.md'
-- Contact: 'contact/support.md'
+
 
 
 
@@ -24,8 +15,6 @@ site_dir: 'site/ask'
 repo_name: 'GitHub'
 
 docs_dir: 'docs_dir'
-
-theme_dir: 'themes'
 
 theme: 'material'
 


### PR DESCRIPTION
Per Andrew's request, pulling out contribute and contact info pages that reference Mozilla 